### PR TITLE
Update test postgres docker compose file

### DIFF
--- a/images/master/docker-compose.postgres.test.yml
+++ b/images/master/docker-compose.postgres.test.yml
@@ -81,6 +81,8 @@ services:
     hostname: powerdns-admin-postgresql
     container_name: powerdns-admin-postgresql
     restart: always
+    networks:
+      - default
     volumes:
       - powerdns-admin-postgresql-data:/var/lib/postgresql/data
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
The postgresql service was missing the required network definition. This caused the powerdns-admin container to fail health checks as the DB container was not in the same network.